### PR TITLE
Fixed wrong base class specified in CBreakable save restore.

### DIFF
--- a/src/game/server/entities/func_break.cpp
+++ b/src/game/server/entities/func_break.cpp
@@ -149,7 +149,7 @@ TYPEDESCRIPTION CBreakable::m_SaveData[] =
 		// Explosion magnitude is stored in pev->impulse
 };
 
-IMPLEMENT_SAVERESTORE(CBreakable, CBaseEntity);
+IMPLEMENT_SAVERESTORE(CBreakable, CBaseDelay);
 
 void CBreakable::Spawn()
 {


### PR DESCRIPTION
See ValveSoftware/halflife#3195.