### PR TITLE
Fixed wrong base class specified in CRecharge save restore.

### DIFF
--- a/src/game/server/entities/items/h_battery.cpp
+++ b/src/game/server/entities/items/h_battery.cpp
@@ -58,7 +58,7 @@ TYPEDESCRIPTION CRecharge::m_SaveData[] =
 	DEFINE_FIELD(CRecharge, m_flSoundTime, FIELD_TIME),
 };
 
-IMPLEMENT_SAVERESTORE(CRecharge, CBaseEntity);
+IMPLEMENT_SAVERESTORE(CRecharge, CBaseToggle);
 
 LINK_ENTITY_TO_CLASS(func_recharge, CRecharge);
 


### PR DESCRIPTION
See ValveSoftware/halflife#3199.