### PR TITLE
Removed duplicate conditions.

### DIFF
--- a/src/game/server/entities/NPCs/zombies/gonome.cpp
+++ b/src/game/server/entities/NPCs/zombies/gonome.cpp
@@ -523,7 +523,7 @@ int COFGonome::IgnoreConditions()
 	{
 		iIgnore |= bits_COND_LIGHT_DAMAGE | bits_COND_HEAVY_DAMAGE | bits_COND_ENEMY_TOOFAR | bits_COND_ENEMY_OCCLUDED;
 	}
-	else if ((m_Activity == ACT_MELEE_ATTACK1) || (m_Activity == ACT_MELEE_ATTACK1))
+	else if (m_Activity == ACT_MELEE_ATTACK1)
 	{
 #if 0
 		if (pev->health < 20)

--- a/src/game/server/entities/NPCs/zombies/zombie.cpp
+++ b/src/game/server/entities/NPCs/zombies/zombie.cpp
@@ -214,7 +214,7 @@ int CZombie::IgnoreConditions()
 {
 	int iIgnore = CBaseMonster::IgnoreConditions();
 
-	if ((m_Activity == ACT_MELEE_ATTACK1) || (m_Activity == ACT_MELEE_ATTACK1))
+	if (m_Activity == ACT_MELEE_ATTACK1)
 	{
 #if 0
 		if (pev->health < 20)


### PR DESCRIPTION
The following changes remove the duplicate check for `ACT_MELEE_ATTACK1` in  zombies IgnoreConditions.

This could have potentially meant `ACT_MELEE_ATTACK2` but actual Gonome and zombies including barney and soldier variants don't have secondary melee attack activities.