### PR TITLE
Add gauss placement mode to FGD.

### DIFF
--- a/config/fgd/halflife-unified.fgd
+++ b/config/fgd/halflife-unified.fgd
@@ -2685,7 +2685,14 @@
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_9mmar.mdl") = weapon_9mmAR : "9mm Assault Rifle" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_shotgun.mdl") = weapon_shotgun : "Shotgun" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_rpg.mdl") = weapon_rpg : "RPG" []
-@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_gauss.mdl") = weapon_gauss : "Gauss Gun" []
+@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_gauss.mdl") = weapon_gauss : "Gauss Gun" 
+[
+  sequence(choices) : "Placement" : 0 =
+  [
+    0 : "Normal (flat)"
+    1 : "Realistic (tilted)"
+  ]
+]
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_crossbow.mdl") = weapon_crossbow : "Crossbow" 
 [
   sequence(choices) : "Placement" : 0 =


### PR DESCRIPTION
The gauss world model has an extra sequence 'onside' which can be set using `"sequence" "1"` keyvalue.

The following changes add the placement option (same as crossbow) to weapon_gauss.

All LD and HD variants include these sequences. Note Opposing Force does not have a separate LD model, and instead imports the one from the base game.