### PR TITLE
Add RPG placement mode to FGD.

### DIFF
--- a/config/fgd/halflife-unified.fgd
+++ b/config/fgd/halflife-unified.fgd
@@ -2684,7 +2684,14 @@
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_357.mdl") = weapon_357 : "357 Handgun" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_9mmar.mdl") = weapon_9mmAR : "9mm Assault Rifle" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_shotgun.mdl") = weapon_shotgun : "Shotgun" []
-@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_rpg.mdl") = weapon_rpg : "RPG" []
+@PointClass base(Weapon, Targetx, RenderFields) studio("models/w_rpg.mdl") = weapon_rpg : "RPG" 
+[
+  sequence(choices) : "Placement" : 0 =
+  [
+    0 : "Normal (flat)"
+    1 : "Realistic (tilted)"
+  ]
+]
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_gauss.mdl") = weapon_gauss : "Gauss Gun" []
 @PointClass base(Weapon, Targetx, RenderFields) studio("models/w_crossbow.mdl") = weapon_crossbow : "Crossbow" 
 [


### PR DESCRIPTION
Same as #327 but with RPG.

The LD variants feature a sequence 'onside', which is currently missing in the HD variants, but a custom HD model will be available and will include the missing sequence.
