### PR TITLE
Fix sentence group percent comment.

### DIFF
--- a/src/game/server/entities/NPCs/scriptevent.h
+++ b/src/game/server/entities/NPCs/scriptevent.h
@@ -24,7 +24,7 @@
 #define SCRIPT_EVENT_INAIR 1006				 // Leave the character in air at the end of the sequence (don't find the floor)
 #define SCRIPT_EVENT_ENDANIMATION 1007		 // Set the animation by name after the sequence completes
 #define SCRIPT_EVENT_SOUND_VOICE 1008		 // Play named wave file (on CHAN_VOICE)
-#define SCRIPT_EVENT_SENTENCE_RND1 1009		 // Play sentence group 25% of the time
+#define SCRIPT_EVENT_SENTENCE_RND1 1009		 // Play sentence group 33% of the time
 #define SCRIPT_EVENT_NOT_DEAD 1010			 // Bring back to life (for life/death sequences)
 #define SCRIPT_EVENT_SOUND_VOICE_BODY 1011	 // Play named wave file with normal attenuation (on CHAN_BODY)
 #define SCRIPT_EVENT_SOUND_VOICE_VOICE 1012	 // Play named wave file with normal attenuation (on CHAN_VOICE)


### PR DESCRIPTION
Event `SCRIPT_EVENT_SENTENCE_RND1` plays a named sentence group 33% of the time but the comment in header states 25%.

https://github.com/SamVanheer/halflife-unified-sdk/blob/d8bd06e4a17ed5c1edffa7d862f2061869536392/src/game/server/entities/NPCs/monsters.cpp#L2661-L2663

https://github.com/SamVanheer/halflife-unified-sdk/blob/d8bd06e4a17ed5c1edffa7d862f2061869536392/src/game/server/entities/NPCs/scriptevent.h#L27