### PR TITLE
Candidate to fix CGrenade Crash #352 (CGrenade null check)

### DIFF
--- a/src/game/server/entities/items/ggrenade.cpp
+++ b/src/game/server/entities/items/ggrenade.cpp
@@ -38,6 +38,12 @@ void CGrenade::OnCreate()
 
 void CGrenade::Precache()
 {
+	// Grenade exploded after save, but hasn't been removed yet. Don't precache.
+	if (pev->model == iStringNull)
+	{
+		return;
+	}
+
 	PrecacheModel(STRING(pev->model));
 }
 


### PR DESCRIPTION
In reference to #352 

Since `pev->model` being null is intended behavior after the grenade explodes, it might be appropriate to simply add a null check to `CGrenade::Precache`

```
// Grenade exploded after save, but hasn't been removed yet. Don't precache.
if (pev->model == iStringNull)
{
	return;
}
```