### PR TITLE
Candidate to fix CGrenade Crash #352 (UTIL_PrecacheModel null/empty string checks)

### DIFF
--- a/src/game/shared/utils/shared_utils.cpp
+++ b/src/game/shared/utils/shared_utils.cpp
@@ -305,6 +305,18 @@ const char* UTIL_CheckForGlobalModelReplacement(const char* s)
 
 int UTIL_PrecacheModel(const char* s)
 {
+	if (s == iStringNull)
+	{
+		ALERT(at_warning, "nullptr string passed to UTIL_PrecacheModel\n");
+		return 0;
+	}
+
+	if (strcmp(s, "") == 0)
+	{
+		ALERT(at_warning, "Empty string passed to UTIL_PrecacheModel\n");
+		return 0;
+	}
+
 	s = UTIL_CheckForGlobalModelReplacement(s);
 
 	return g_engfuncs.pfnPrecacheModel(s);


### PR DESCRIPTION
In reference to #352 

While this applies to more than just `CGrenade`, this prevents obviously invalid strings from being passed to `g_engfuncs.pfnPrecacheModel` and prints a warning to the console when it happens. It also provides a convenient point in the dlls to set a breakpoint to diagnose the issue when it occurs. In some cases, such as #352 , the game will continue function without issue even if the precache fails.

```
int UTIL_PrecacheModel(const char* s)
{
	if (s == iStringNull)
	{
		ALERT(at_warning, "nullptr string passed to UTIL_PrecacheModel\n");
		return 0;
	}

	if (strcmp(s, "") == 0)
	{
		ALERT(at_warning, "Empty string passed to UTIL_PrecacheModel\n");
		return 0;
	}

	s = UTIL_CheckForGlobalModelReplacement(s);

	return g_engfuncs.pfnPrecacheModel(s);
}
```