### PR TITLE
Check for zero dimension textures.

### DIFF
--- a/utils/studiomdl/studiomdl.cpp
+++ b/utils/studiomdl/studiomdl.cpp
@@ -1610,7 +1610,14 @@ void ResizeTexture(s_texture_t* ptexture)
 	ptexture->skinleft = ptexture->min_s;
 
 	ptexture->skinwidth = GetSkinWidth(ptexture->max_s - ptexture->min_s + 1);
+	
+	if (0 == ptexture->skinwidth)
+		Error("%s final skin width is 0\n", ptexture->name);
+
 	ptexture->skinheight = GetSkinHeight(ptexture->max_t - ptexture->min_t + 1);
+
+	if (0 == ptexture->skinheight)
+		Error("%s final skin height is 0\n", ptexture->name);
 
 	ptexture->size = ptexture->skinwidth * ptexture->skinheight + 256 * 3;
 


### PR DESCRIPTION
**Important:** #356 and #357 must have been merged:

If a triangle has at least 2 vertices with the same UVs then Min and Max for S and or T may possibly end up being equal to each other. Depending on which range is affected, both skin dimension(s) could be null because of  `max_s - min_s <=> 0` and or `max_t - min_t <=> 0`.

The changes add checks to ensure `skinwidth` and `skinheight` are not null.