### PR TITLE
Always return at least one bodygroup in GetBodygroupSubmodelCount

### DIFF
--- a/src/game/server/entities/animating.cpp
+++ b/src/game/server/entities/animating.cpp
@@ -248,10 +248,10 @@ int CBaseAnimating::GetBodygroupSubmodelCount(int group)
 	auto pstudiohdr = reinterpret_cast<studiohdr_t*>(GET_MODEL_PTR(ENT(pev)));
 
 	if (!pstudiohdr)
-		return 0;
+		return 1;
 
 	if (group < 0 || group >= pstudiohdr->numbodyparts)
-		return 0;
+		return 1;
 
 	auto pbodypart = (mstudiobodyparts_t*)((byte*)pstudiohdr + pstudiohdr->bodypartindex) + group;
 


### PR DESCRIPTION
It doesn't make sense to return 0 here, as model always have at least one body group for any body part. Even if model doesn't exist.
Otherwise, we may encounter divison-by-zero errors in simple code like:

    switch (GetBodygroup(ScientistBodygroup::Head) % GetBodygroupSubmodelCount(ScientistBodygroup::Head))