### PR TITLE
Set specific hull for holo pushcart model.

### DIFF
--- a/src/game/server/entities/NPCs/other/genericmonster.cpp
+++ b/src/game/server/entities/NPCs/other/genericmonster.cpp
@@ -138,7 +138,7 @@ void CGenericMonster::Spawn()
 			UTIL_SetSize(pev, VEC_HULL_MIN, VEC_HULL_MAX);
 	*/
 
-	if (FStrEq(STRING(pev->model), "models/player.mdl") || FStrEq(STRING(pev->model), "models/holo.mdl"))
+	if (FStrEq(STRING(pev->model), "models/player.mdl") || FStrEq(STRING(pev->model), "models/holo.mdl") || FStrEq(STRING(pev->model), "models/holo_cart.mdl"))
 		UTIL_SetSize(pev, VEC_HULL_MIN, VEC_HULL_MAX);
 	else
 		UTIL_SetSize(pev, VEC_HUMAN_HULL_MIN, VEC_HUMAN_HULL_MAX);


### PR DESCRIPTION
See #431

In addition, because `holo_cart.mdl` uses the same model setup as `holo.mdl` it is centered halfway up and not at the feet. It must be added in genericmonster.cpp so the correct hull is set.

https://github.com/SamVanheer/halflife-unified-sdk/blob/f47c2f6a405aa33b386b63188067e1853484687e/src/game/server/entities/NPCs/other/genericmonster.cpp#L141-L144

The following changes were tested in Debug/Release with the new map updated with https://github.com/SamVanheer/HalfLife.UnifiedSdk-CSharp/pull/3.