### PR TITLE
Fix Barney playing post-disaster use/unuse sentences in training.

### DIFF
--- a/src/game/server/entities/NPCs/blackmesa/barney.cpp
+++ b/src/game/server/entities/NPCs/blackmesa/barney.cpp
@@ -701,7 +701,7 @@ bool CBarney::KeyValue(KeyValueData* pkvd)
 		return true;
 	}
 
-	return CBaseMonster::KeyValue(pkvd);
+	return CTalkMonster::KeyValue(pkvd);
 }
 
 //=========================================================


### PR DESCRIPTION
See #432.

The changes were tested in game:
- Use/Unuse sentences in training `t0a0d`
- Use/Unuse sentences in campaign