### PR TITLE
Mark bones that are referenced by attachment as used.

### DIFF
--- a/utils/studiomdl/studiomdl.cpp
+++ b/utils/studiomdl/studiomdl.cpp
@@ -401,6 +401,17 @@ void SimplifyModel(void)
 		}
 		for (k = 0; k < MAXSTUDIOSRCBONES; k++)
 		{
+			// Check if a bone is referenced by an attachment.
+			for (j = 0; j < numattachments; j++)
+			{
+				if (0 == stricmp(attachment[j].bonename, model[i]->node[k].name))
+				{
+					model[i]->boneref[k] = 1;
+				}
+			}
+		}
+		for (k = 0; k < MAXSTUDIOSRCBONES; k++)
+		{
 			// tag parent bones as used if child has been used
 			if (model[i]->boneref[k])
 			{

--- a/utils/studiomdl/studiomdl.h
+++ b/utils/studiomdl/studiomdl.h
@@ -352,7 +352,7 @@ typedef struct s_model_s
 	int numbones;
 	s_node_t node[MAXSTUDIOSRCBONES];
 	s_bone_t skeleton[MAXSTUDIOSRCBONES];
-	int boneref[MAXSTUDIOSRCBONES];	 // is local bone (or child) referenced with a vertex
+	int boneref[MAXSTUDIOSRCBONES];	 // is local bone (or child) referenced with a vertex, and or attachment
 	int bonemap[MAXSTUDIOSRCBONES];	 // local bone to world bone mapping
 	int boneimap[MAXSTUDIOSRCBONES]; // world bone to local bone mapping
 


### PR DESCRIPTION
See the following issues:

https://github.com/malortie/custom-hl-viewmodels/issues/98
#426

The following changes mark all bones referenced by attachments as used so that the code [won't skip them](https://github.com/SamVanheer/halflife-unified-sdk/blob/f47c2f6a405aa33b386b63188067e1853484687e/utils/studiomdl/studiomdl.cpp#L443) when creating the union of all used bones.
 
A binary comparison has been with all models made against those compiled with the actual studiomdl release (master).

All models were binary equal except the following:

```
hd/
  bshift/
    v_shock.mdl
    v_shotgun.mdl
  op4/
    v_shock.mdl
    v_shotgun.mdl

  hgrunt_medic.mdl
  hgrunt_opfor.mdl
  hgrunt_torch.mdl
  intro_commander.mdl
  intro_medic.mdl
  intro_regular.mdl
  intro_saw.mdl
  intro_torch.mdl
  v_shock.mdl
  v_shotgun.mdl

ld/
  bshift/
    v_shock.mdl
  op4/
    v_shock.mdl

  hgrunt_medic.mdl
  hgrunt_opfor.mdl
  hgrunt_torch.mdl
  intro_commander.mdl
  intro_medic.mdl
  intro_regular.mdl
  intro_saw.mdl
  intro_torch.mdl
  otis.mdl
  v_shock.mdl
```

Note that it is expected for the shock viewmodels to be different since the quad meshes have been removed. See https://github.com/SamVanheer/halflife-unified-sdk-assets/pull/13. The other models difference might be due to offsets differing from those in the previous models.

In HLAM Model Info pane, all models except `v_shock.mdl` appear to have the same stats as their previous counterpart.

The modified models were tested in game both LD and HD. No issue has been found.