### PR TITLE
Add build folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Allow Half-Life-specific files that would otherwise be ignored
 !utils/procinfo/lib/win32_vc6/procinfo.lib
+build/


### PR DESCRIPTION
By convention, many CMake users build their project in build folder in git repo. Although this is not the recommended way for HalfLife Unified SDK, this can prevent confusion and mistakes by people who are doing so.