### PR TITLE
client: register joysupported cvar to be able to use gamepads on HL25

### DIFF
--- a/src/game/client/input/inputw32.cpp
+++ b/src/game/client/input/inputw32.cpp
@@ -1038,6 +1038,11 @@ void IN_Init()
 	joy_wwhack1 = gEngfuncs.pfnRegisterVariable("joywwhack1", "0.0", 0);
 	joy_wwhack2 = gEngfuncs.pfnRegisterVariable("joywwhack2", "0.0", 0);
 
+	// HL25 checks this cvar and if it doesn't exist or set to zero
+	// it will lock any usage of gamepads
+	// see: https://github.com/ValveSoftware/halflife/issues/3621
+	gEngfuncs.pfnRegisterVariable("joysupported", "1", 0);
+
 	m_customaccel = gEngfuncs.pfnRegisterVariable("m_customaccel", "0", FCVAR_ARCHIVE);
 	m_customaccel_scale = gEngfuncs.pfnRegisterVariable("m_customaccel_scale", "0.04", FCVAR_ARCHIVE);
 	m_customaccel_max = gEngfuncs.pfnRegisterVariable("m_customaccel_max", "0", FCVAR_ARCHIVE);


### PR DESCRIPTION
See https://github.com/ValveSoftware/halflife/issues/3621